### PR TITLE
Feature/fuji

### DIFF
--- a/focuspoints.lrdevplugin/DefaultDelegates.lua
+++ b/focuspoints.lrdevplugin/DefaultDelegates.lua
@@ -19,6 +19,7 @@
 --]]
 
 local LrStringUtils = import "LrStringUtils"
+local LrErrors = import 'LrErrors'
 require "Utils"
 
 DefaultDelegates = {}
@@ -36,7 +37,8 @@ function DefaultDelegates.getDefaultAfPoints(metaData)
     focusPoint = ExifUtils.findValue(metaData, "Primary AF Point")
   end
 
-  if "(none)" == focusPoint then
+  if "(none)" == focusPoint or focusPoint == nil then
+    LrErrors.throwUserError("Unable to find any AF point info within the file.")
     return nil, nil
   end
   

--- a/focuspoints.lrdevplugin/DefaultDelegates.lua
+++ b/focuspoints.lrdevplugin/DefaultDelegates.lua
@@ -1,0 +1,66 @@
+--[[
+  Copyright 2016 Joshua Musselwhite, Whizzbang Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--]]
+
+--[[
+  A collection of delegate functions to be passed into the DefaultPointRenderer. 
+--]]
+
+local LrStringUtils = import "LrStringUtils"
+require "Utils"
+
+DefaultDelegates = {}
+DefaultDelegates.focusPointsMap = nil
+
+
+--[[
+-- metaData - the metadata as read by exiftool
+-- focusPoints - table containing px locations of the focus points
+--]]
+function DefaultDelegates.getDefaultAfPoints(metaData)
+  local focusPoint = ExifUtils.findValue(metaData, "AF Points Used")
+
+  if "(none)" == focusPoint then
+    focusPoint = ExifUtils.findValue(metaData, "Primary AF Point")
+  end
+
+  if "(none)" == focusPoint then
+    return nil, nil
+  end
+  
+  local x = DefaultDelegates.focusPointsMap[focusPoint][1]
+  local y = DefaultDelegates.focusPointsMap[focusPoint][2]
+
+  return x, y
+end
+
+--[[
+  -- method figures out the orientation the photo was shot at by looking at the metadata
+  -- returns 90, 270, or 0
+--]]
+function DefaultDelegates.getShotOrientation(photo, metaData)
+  local dimens = photo:getFormattedMetadata("dimensions")
+  local orgPhotoW, orgPhotoH = parseDimens(dimens) -- original dimension before any cropping
+  
+  local metaOrientation = ExifUtils.findValue(metaData, "Orientation")
+  if (string.match(metaOrientation, "90") and orgPhotoW < orgPhotoH) then
+    return 90
+  elseif (string.match(metaOrientation, "270") and orgPhotoW < orgPhotoH) then
+    return 270
+  else 
+    return 0
+  end
+  
+end

--- a/focuspoints.lrdevplugin/DefaultPointRenderer.lua
+++ b/focuspoints.lrdevplugin/DefaultPointRenderer.lua
@@ -28,9 +28,11 @@ local LrErrors = import 'LrErrors'
 require "ExifUtils"
 
 DefaultPointRenderer = {}
+
+--[[ the factory will set these delegate methods with the appropriate function depending upon the camera --]]
 DefaultPointRenderer.funcGetAFPixels = nil
 DefaultPointRenderer.funcGetShotOrientation = nil
-DefaultPointRenderer.focusPointDimen = {300, 250}
+DefaultPointRenderer.focusPointDimen = nil
 
 --[[
 -- targetPhoto - the selected catalog photo

--- a/focuspoints.lrdevplugin/DefaultPointRenderer.lua
+++ b/focuspoints.lrdevplugin/DefaultPointRenderer.lua
@@ -28,19 +28,16 @@ local LrErrors = import 'LrErrors'
 require "ExifUtils"
 
 DefaultPointRenderer = {}
-DefaultPointRenderer.metaOrientation90 = "90"
-DefaultPointRenderer.metaOrientation270 = "270"
-DefaultPointRenderer.metaAFUsed = "AF Points Used"
-DefaultPointRenderer.metaPrimaryAFPoint = "Primary AF Point"
-DefaultPointRenderer.metaOrientation = "Orientation"
+DefaultPointRenderer.funcGetAFPixels = nil
+DefaultPointRenderer.funcGetShotOrientation = nil
+DefaultPointRenderer.focusPointDimen = {300, 250}
 
 --[[
 -- targetPhoto - the selected catalog photo
 -- photoDisplayW, photoDisplayH - the width and height that the photo view is going to display as.
--- focusPoints - table containing app of the map focus points needed
--- focusPointDimen - table of dimension for the focus point. e.g. 300px x 200px is how big the D7200 focus point is
 --]]
-function DefaultPointRenderer.createView(targetPhoto, photoDisplayW, photoDisplayH, focusPoints, focusPointDimen)
+function DefaultPointRenderer.createView(targetPhoto, photoDisplayW, photoDisplayH)
+  local focusPointDimen = DefaultPointRenderer.focusPointDimen 
   local developSettings = targetPhoto:getDevelopSettings()
   local metaData = readMetaData(targetPhoto)
   local dimens = targetPhoto:getFormattedMetadata("dimensions")
@@ -48,33 +45,26 @@ function DefaultPointRenderer.createView(targetPhoto, photoDisplayW, photoDispla
   local croppedDimens = targetPhoto:getFormattedMetadata("croppedDimensions")
   local croppedPhotoW, croppedPhotoH = parseDimens(croppedDimens) -- cropped size of the photo
   
-  
-  local focusPoint = DefaultPointRenderer.getAutoFocusPoint(metaData)
-
-  if nil == focusPoint then
-    LrErrors.throwUserError( "Unable to find any AF point info within the file." )
-    return
-  end
-
-  local x = focusPoints[focusPoint][1]
-  local y = focusPoints[focusPoint][2]
+  local pX, pY = DefaultPointRenderer.funcGetAFPixels(metaData)
+  local x = pX
+  local y = pY
   
   local leftCropAmount = developSettings["CropLeft"] * orgPhotoW
   local topCropAmount = developSettings["CropTop"] * orgPhotoH
-  local metaOrientation = DefaultPointRenderer.getOrientation(metaData)
+  local shotOrientation = DefaultPointRenderer.funcGetShotOrientation(targetPhoto, metaData)
   
   --[[ lightroom does not report if a photo has been rotated. code below 
         make sure the rotation matches the expected width and height --]]
   local isRotated = false
-  if (string.match(metaOrientation, DefaultPointRenderer.metaOrientation90) and orgPhotoW < orgPhotoH) then
+  if (shotOrientation == 90) then
     x = orgPhotoW - y - focusPointDimen[1]
-    y = focusPoints[focusPoint][1]
+    y = pX
     leftCropAmount = (1- developSettings["CropBottom"]) * orgPhotoW
     topCropAmount = developSettings["CropLeft"] * orgPhotoH
     isRotated = true
-  elseif (string.match(metaOrientation, DefaultPointRenderer.metaOrientation270) and orgPhotoW < orgPhotoH) then
-    x = focusPoints[focusPoint][2]
-    y = orgPhotoH - focusPoints[focusPoint][1] - focusPointDimen[1]
+  elseif (shotOrientation == 270) then
+    x = pY
+    y = orgPhotoH - pX - focusPointDimen[1]
     leftCropAmount = developSettings["CropTop"] * orgPhotoW
     topCropAmount = (1-developSettings["CropRight"]) * orgPhotoH
     isRotated = true
@@ -127,22 +117,3 @@ function DefaultPointRenderer.buildView(focusPointX, focusPointY, isRotated)
   
 end
 
-
-function DefaultPointRenderer.getAutoFocusPoint(metaData)
-  local focusPointUsed = ExifUtils.findValue(metaData, DefaultPointRenderer.metaAFUsed)
-
-  if "(none)" == focusPointUsed then
-    focusPointUsed = ExifUtils.findValue( metaData, DefaultPointRenderer.metaPrimaryAFPoint )
-  end
-
-  if "(none)" == focusPointUsed then
-    focusPointUsed = nil
-  end
-
-  return focusPointUsed
-end
-
-function DefaultPointRenderer.getOrientation(metaData)
-  local orientation = ExifUtils.findValue(metaData, DefaultPointRenderer.metaOrientation)
-  return orientation
-end

--- a/focuspoints.lrdevplugin/FocusPoint.lua
+++ b/focuspoints.lrdevplugin/FocusPoint.lua
@@ -45,12 +45,6 @@ local function showDialog()
         LrDialogs.message("Unmapped points renderer.", nil, nil)
         return
       end
-      local focusPoints, focusPointDimens = PointsRendererFactory.getFocusPoints(targetPhoto)
-      if (focusPointDimens == nil) then focusPointDimens = {300, 250} end
-      if (type(focusPoints) == "string") then
-        LrDialogs.message(focusPoints, nil, nil)
-        return
-      end
       
       -- let the renderer build the view now and show progress dialog
       LrFunctionContext.callWithContext("innerContext", function(dialogContext)
@@ -63,7 +57,7 @@ local function showDialog()
         }
         dialogScope:setIndeterminate()
         -- not local overlay. Need the scope outside for the dialog box below
-        overlay = rendererTable.createView(targetPhoto, photoW, photoH, focusPoints, focusPointDimens)
+        overlay = rendererTable.createView(targetPhoto, photoW, photoH, {300, 250})
       end)
       FocusPointDialog.createDialog(targetPhoto, overlay)
       

--- a/focuspoints.lrdevplugin/FocusPoint.lua
+++ b/focuspoints.lrdevplugin/FocusPoint.lua
@@ -57,7 +57,7 @@ local function showDialog()
         }
         dialogScope:setIndeterminate()
         -- not local overlay. Need the scope outside for the dialog box below
-        overlay = rendererTable.createView(targetPhoto, photoW, photoH, {300, 250})
+        overlay = rendererTable.createView(targetPhoto, photoW, photoH)
       end)
       FocusPointDialog.createDialog(targetPhoto, overlay)
       

--- a/focuspoints.lrdevplugin/FujiDelegates.lua
+++ b/focuspoints.lrdevplugin/FujiDelegates.lua
@@ -1,0 +1,39 @@
+--[[
+  Copyright 2016 Joshua Musselwhite, Whizzbang Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--]]
+
+--[[
+  A collection of delegate functions to be passed into the DefaultPointRenderer when
+  the camera is Fuji 
+--]]
+
+local LrStringUtils = import "LrStringUtils"
+require "Utils"
+
+FujiDelegates = {}
+
+--[[
+-- metaData - the metadata as read by exiftool
+--]]
+function FujiDelegates.getFujiAfPoints(metaData)
+  local focusPoint = ExifUtils.findValue(metaData, "Focus Pixel")
+  if focusPoint == nil then return nil end
+  local values = splitText(focusPoint, " ")
+  local x = LrStringUtils.trimWhitespace(values.key)
+  local y = LrStringUtils.trimWhitespace(values.value)
+  
+  return tonumber(x), tonumber(y)
+  
+end

--- a/focuspoints.lrdevplugin/PointsRendererFactory.lua
+++ b/focuspoints.lrdevplugin/PointsRendererFactory.lua
@@ -34,9 +34,10 @@ function PointsRendererFactory.createRenderer(photo)
       DefaultPointRenderer.funcGetAFPixels = FujiDelegates.getFujiAfPoints
       DefaultPointRenderer.focusPointDimen = {1,1}
   else 
-    DefaultDelegates.focusPointsMap = PointsRendererFactory.getFocusPoints(photo)
+    local pointsMap, pointDimen = PointsRendererFactory.getFocusPoints(photo)
+    DefaultDelegates.focusPointsMap = pointsMap
     DefaultPointRenderer.funcGetAFPixels = DefaultDelegates.getDefaultAfPoints
-    DefaultPointRenderer.focusPointDimen = DefaultDelegates.focusPointsMap.focusPointDimens
+    DefaultPointRenderer.focusPointDimen = pointDimen
   end
   
   DefaultPointRenderer.funcGetShotOrientation = DefaultDelegates.getShotOrientation

--- a/focuspoints.lrdevplugin/PointsRendererFactory.lua
+++ b/focuspoints.lrdevplugin/PointsRendererFactory.lua
@@ -21,16 +21,32 @@
 
 require "DefaultPointRenderer"
 require "PointsUtils"
+require "DefaultDelegates"
+require "FujiDelegates"
+local LrErrors = import 'LrErrors'
 
 PointsRendererFactory = {}
 
 function PointsRendererFactory.createRenderer(photo)
+  local cameraMake = photo:getFormattedMetadata("cameraMake")
+  local cameraModel = photo:getFormattedMetadata("cameraModel")
+  if (cameraMake == "FUJIFILM") then
+      DefaultPointRenderer.funcGetAFPixels = FujiDelegates.getFujiAfPoints
+      DefaultPointRenderer.focusPointDimen = {1,1}
+  else 
+    DefaultDelegates.focusPointsMap = PointsRendererFactory.getFocusPoints(photo)
+    DefaultPointRenderer.funcGetAFPixels = DefaultDelegates.getDefaultAfPoints
+    DefaultPointRenderer.focusPointDimen = DefaultDelegates.focusPointsMap.focusPointDimens
+  end
+  
+  DefaultPointRenderer.funcGetShotOrientation = DefaultDelegates.getShotOrientation
   return DefaultPointRenderer
 end
 
 function PointsRendererFactory.getFocusPoints(photo)
   local cameraMake = photo:getFormattedMetadata("cameraMake")
   local cameraModel = photo:getFormattedMetadata("cameraModel")
+  
   local focusPoints, focusPointDimens =  PointsUtils.readIntoTable(string.lower(cameraMake), string.lower(cameraModel) .. ".txt")
   
   if (focusPoints == nil) then

--- a/focuspoints.lrdevplugin/PointsUtils.lua
+++ b/focuspoints.lrdevplugin/PointsUtils.lua
@@ -56,7 +56,7 @@ function PointsUtils.readIntoTable(folder, filename)
       y = LrStringUtils.trimWhitespace(y)
       points[1] = tonumber(x)
       points[2] = tonumber(y)
-      -- log("pointName: " .. pointName .. ", x: " .. x .. ", y: " .. y)
+      --log("pointName: " .. pointName .. ", x: " .. x .. ", y: " .. y)
       
       if (pointName == "focusPointDimens") then
         focusPointDimens = points


### PR DESCRIPTION
Refactor to allow for delegates for injecting logic into the DefaultPointRenderer. This allows for delegates to handle their own metadata for looking up orientation or looking up the x,y location. DefaultPointRenderer is now returned with everything that is needed rather than a 2 step process. 