### PR TITLE
Rewrote MetaDataDialog

### DIFF
--- a/focuspoints.lrdevplugin/MetaDataDialog.lua
+++ b/focuspoints.lrdevplugin/MetaDataDialog.lua
@@ -23,37 +23,33 @@ local LrView = import 'LrView'
 local LrTasks = import 'LrTasks'
 local LrFileUtils = import 'LrFileUtils'
 local LrPathUtils = import 'LrPathUtils'
+local LrStringUtils = import 'LrStringUtils'
 
 MetaDataDialog = {}
 
-function MetaDataDialog.create()
+function MetaDataDialog.create(values)
 
   local appWidth, appHeight = LrSystemInfo.appWindowSize()
-  local viewFactory = LrView.osFactory()
+  local v = LrView.osFactory()
   
-  local myText = viewFactory:static_text {
-    title = "Will place label here",
-    selectable = true, 
-  }
+  local rows = {}
   
-  local myText2 = viewFactory:static_text {
-    title = "Will place data here",
-    selectable = true, 
-  }
+  for k in pairs(values) do
+    local key = values[k].key
+    local value = values[k].value
+    if (key == nill) then key = "" end
+    if (value == nill) then value = "" end
+    key = LrStringUtils.trimWhitespace(key)
+    value = LrStringUtils.trimWhitespace(value)
+    values[k].title = key .. " = " .. value
+  end
   
-  local row = viewFactory:row {
-    myText, myText2, 
-    margin_left = 5, 
-  }
-  
-  local scrollView = viewFactory:scrolled_view {
-    row, 
+  local view = v:simple_list {
+    items = values,
     width = appWidth * .7,
-    height = appHeight *.7,
+    height = appHeight * .7,
   }
   
-  MetaDataDialog.contents = scrollView
-  MetaDataDialog.labels = myText
-  MetaDataDialog.data = myText2
+  MetaDataDialog.contents = view
   
 end

--- a/focuspoints.lrdevplugin/ShowMetadata.lua
+++ b/focuspoints.lrdevplugin/ShowMetadata.lua
@@ -30,7 +30,6 @@ require "Utils"
 local function showDialog()
   LrFunctionContext.callWithContext("showDialog", function(context)
   
-  MetaDataDialog.create()
   local catalog = LrApplication.activeCatalog()
   local targetPhoto = catalog:getTargetPhoto()
   
@@ -49,28 +48,36 @@ local function showDialog()
     
           local metaData = readMetaData(targetPhoto)
           metaData = filterInput(metaData)
-          local column1, column2 = splitForColumns(metaData)
+          --local column1, column2 = splitForColumns(metaData)
         
           dialogScope:done()
-          MetaDataDialog.labels.title = column1
-          MetaDataDialog.data.title = column2
+          --log("Column 1:" .. column1)
+          --log("Column 2:" .. column2)
+          MetaDataDialog.create(createParts(metaData))
           --MetaDataDialog.labels.title = "parts: "  .. parts[1].key
+          --log("Labels title:" .. MetaDataDialog.labels.title)
+          --log("Data title:" .. MetaDataDialog.data.title)
+          LrDialogs.presentModalDialog {
+            title = "Metadata display",
+            resizable = true, 
+            cancelVerb = "< exclude >",
+            actionVerb = "OK",
+            contents = MetaDataDialog.contents
+          }
         end)
     
       LrTasks.sleep(0)
-      LrDialogs.presentModalDialog {
-        title = "Metadata display",
-        resizable = true, 
-        cancelVerb = "< exclude >",
-        actionVerb = "OK",
-        contents = MetaDataDialog.contents
-      }
     
     end)
   end)
 end)
 end
 showDialog()
+
+local endOfLine = "\r";
+if (WIN_ENV) then
+  endOfLine = "\n";
+end
 
 function splitForColumns(metaData)
   local parts = createParts(metaData)
@@ -84,8 +91,8 @@ function splitForColumns(metaData)
     l = LrStringUtils.trimWhitespace(l)
     v = LrStringUtils.trimWhitespace(v)
     
-    labels = labels .. l .. "\r"
-    values = values .. v .. "\r"
+    labels = labels .. l .. endOfLine
+    values = values .. v .. endOfLine
   end
   return labels, values
   

--- a/focuspoints.lrdevplugin/Utils.lua
+++ b/focuspoints.lrdevplugin/Utils.lua
@@ -24,7 +24,7 @@ local LrTasks = import 'LrTasks'
 local LrFileUtils = import 'LrFileUtils'
 local LrPathUtils = import 'LrPathUtils'
 local LrLogger = import 'LrLogger'
-local LrStringUtils = import "LrStringUtils"
+local LrStringUtils = import 'LrStringUtils'
 
 local myLogger = LrLogger( 'libraryLogger' )
 myLogger:enable( "logfile" )
@@ -46,8 +46,10 @@ function getExifCmd(targetPhoto)
   local metaDataFile = LrPathUtils.removeExtension(path)
   metaDataFile = metaDataFile .. "-metadata.txt"
   
-  -- local cmd = "\"'" .. exiftool .. "' -a -u -g1 '" .. path .. "' > '" .. metaDataFile .. "'\"";
-  local cmd = "\"\"".. exiftool .. "\" -a -u -g1 \"" .. path .. "\" > \"" .. metaDataFile .. "\"\""
+  local cmd = "\"'" .. exiftool .. "' -a -u -g1 '" .. path .. "' > '" .. metaDataFile .. "'\"";
+  if (WIN_ENV) then
+    cmd = "\"\"".. exiftool .. "\" -a -u -g1 \"" .. path .. "\" > \"" .. metaDataFile .. "\"\""
+  end
   log("ExifTool command: " .. cmd)
   return cmd, metaDataFile
   
@@ -62,9 +64,8 @@ function readMetaData(targetPhoto)
 end
 
 function filterInput(str)
-  --local result = string.gsub(str, "[^a-zA-Z0-9 ,\\./;'\\<>\\?:\\\"\\{\\}\\|!@#\\$%\\^\\&\\*\\(\\)_\\+\\=-\\[\\]~`]", "?");
   -- FIXME: doesn't strip - or ] correctly
-  local result = string.gsub(str, "[^a-zA-Z0-9 ,\\./;'\\<>\\?:\\\"\\{\\}\\|!@#\\$%\\^\\&\\*\\(\\)_\\+\\=\\-\\[\\\n\\\t~`-]", "?");
+  local result = string.gsub(str, "[^a-zA-Z0-9 ,\\./;'\\<>\\?:\\\"\\{\\}\\|!@#\\$%\\^\\&\\*\\(\\)_\\+\\=\\-\\[\\]~`]", "?");
   -- log("filterInput result:" .. result)
   return result
 end


### PR DESCRIPTION
- Made the dialog Windows compatible (properties are immutable on Windows, or so it appears)
- Changed the dialog to show a simple_list of "key = value" rows.
- Don't replace '\n' by '?' in the metadata. '\n' is the end-of-line character on Windows.

The layout might be worse (I don't know, since the MetaDataDialog never worked on Windows) but at least you can see all the metadata now.

Please check it out and maybe if someone who's better at LrViews can create a nice looking table out of the key-value pairs.