### PR TITLE
Replace 'nill' with 'nil'

### DIFF
--- a/focuspoints.lrdevplugin/Info.lua
+++ b/focuspoints.lrdevplugin/Info.lua
@@ -44,7 +44,7 @@ return {
 
 --[[ 
 KNOWN BUGS: 
- 1. LrPhoto.getDevelopmentSettings()["Orientation"] return nill. I have no way of knowing if the photo
+ 1. LrPhoto.getDevelopmentSettings()["Orientation"] return nil. I have no way of knowing if the photo
         was rotated in development mode
  2. Orientation must be determined from the metadata. The metdata does not tell me if the camera was upside down
         e.g. rotation of 180 degrees. It only tells me normal, 90, or 270

--- a/focuspoints.lrdevplugin/OlympusDelegates.lua
+++ b/focuspoints.lrdevplugin/OlympusDelegates.lua
@@ -80,7 +80,7 @@ function OlympusDelegates.getAfPoints(photo, metaData)
   local afAreaWidth = 300
   local afAreaHeight = 300
 
-  if (afAreaX1 ~= nill and afAreaY1 ~= nill and afAreaX2 ~= nill and afAreaY2 ~= nill ) then
+  if afAreaX1 ~= nil and afAreaY1 ~= nil and afAreaX2 ~= nil and afAreaY2 ~= nil then
       afAreaWidth = math.abs(tonumber(afAreaX2) - tonumber(afAreaX1)) * tonumber(orgPhotoWidth) / 255
       afAreaHeight = math.abs(tonumber(afAreaY2) - tonumber(afAreaY1)) * tonumber(orgPhotoHeight) / 255
   end

--- a/focuspoints.lrdevplugin/PointsUtils.lua
+++ b/focuspoints.lrdevplugin/PointsUtils.lua
@@ -42,7 +42,7 @@ function PointsUtils.readIntoTable(folder, filename)
   if (data == nil) then return nil end
   for i in string.gmatch(data, "[^\\\n]+") do
     p = splitToKeyValue(i, "=")
-    if (p ~= nill) then
+    if p ~= nil then
       local pointName = p.key
 
       pointName = LrStringUtils.trimWhitespace(pointName)

--- a/focuspoints.lrdevplugin/ShowMetadata.lua
+++ b/focuspoints.lrdevplugin/ShowMetadata.lua
@@ -80,8 +80,8 @@ function splitForColumns(metaData)
     local l = parts[k].key
     
     local v = parts[k].value
-    if (l == nill) then l = "" end
-    if (v == nill) then v = "" end
+    if l == nil then l = "" end
+    if v == nil then v = "" end
     l = LrStringUtils.trimWhitespace(l)
     v = LrStringUtils.trimWhitespace(v)
     
@@ -105,7 +105,7 @@ function createParts(metaData)
   for i in string.gmatch(metaData, "[^\\\n]+") do 
     logDebug("ShowMetadata", "i = " .. i)
     p = stringToKeyValue(i, ":")
-    if (p ~= nill) then
+    if p ~= nil then
       parts[num] = p
       num = num+1
     end

--- a/focuspoints.lrdevplugin/Utils.lua
+++ b/focuspoints.lrdevplugin/Utils.lua
@@ -41,10 +41,10 @@ isDebug = false
 -- delim - delimiter
 --]]
 function splitToKeyValue(str, delim)
-  if str == nill then return nill end
+  if str == nil then return nil end
   local index = string.find(str, delim)
-  if index == nill then
-    return nill
+  if index == nil then
+    return nil
   end
   local r = {}
   r.key = string.sub(str, 0, index-1)
@@ -74,10 +74,10 @@ end
  @delim the character used for splitting the string
 --]]
 function stringToKeyValue(str, delim)
-  if str == nill then return nill end
+  if str == nil then return nil end
   local index = string.find(str, delim)
-  if index == nill then
-    return nill
+  if index == nil then
+    return nil
   end
   local r = {}
   r.key = string.sub(str, 0, index-1)
@@ -158,7 +158,7 @@ end
 --]]
 function parseDimens(strDimens)
   local index = string.find(strDimens, "x")
-  if (index == nill) then return nill end
+  if index == nil then return nil end
   local w = string.sub(strDimens, 0, index-1)
   local h = string.sub(strDimens, index+1)
   w = LrStringUtils.trimWhitespace(w)


### PR DESCRIPTION
Some of the code uses 'nill' instead of 'nil'.
'nill' is an undefined variable, which defaults to a value of 'nil' so the end result is the same, just not standard usage.