### PR TITLE
Pentax: refined focus modes and added error messages

### DIFF
--- a/focuspoints.lrdevplugin/PentaxDelegates.lua
+++ b/focuspoints.lrdevplugin/PentaxDelegates.lua
@@ -25,6 +25,8 @@
   Notes:
   * Back focus button sets AFPointsInFocus to 'None' regardless of point
     selection mode (sucks). AFPointSelected is set correctly with either button.
+  * For phase detection AF, the coordinates taken from the point map represent 
+    the center of each AF point.
 
   2017.03.29 - roguephysicist: works for Pentax K-50 with both phase and contrast detection
 --]]
@@ -42,6 +44,7 @@ PentaxDelegates.focusPointDimen = nil
 function PentaxDelegates.getAfPoints(photo, metaData)
   local focusMode = ExifUtils.findFirstMatchingValue(metaData, { "Focus Mode" })
   focusMode = splitTrim(focusMode, " ")
+  local result = nil
   if focusMode[1] == "AF-A" or focusMode[1] == "AF-C" or focusMode[1] == "AF-S" then
     result = PentaxDelegates.getAfPointsPhase(photo, metaData)
   elseif focusMode[1] == "Contrast-detect" then

--- a/focuspoints.lrdevplugin/focus_points/pentax/pentax k-50.txt
+++ b/focuspoints.lrdevplugin/focus_points/pentax/pentax k-50.txt
@@ -2,8 +2,6 @@
 -- Submitted by: roguephysicist
 -- 16.3 MP, 4928x3264
 -- AF System: 11 points, 9 cross-type
--- selected points: AFPointSelected
--- in-focus points: AFPointsInFocus
 
 -- point dimensions
 focusPointDimens = {250, 250}

--- a/focuspoints.lrdevplugin/focus_points/pentax/pentax k-50.txt
+++ b/focuspoints.lrdevplugin/focus_points/pentax/pentax k-50.txt
@@ -2,6 +2,7 @@
 -- Submitted by: roguephysicist
 -- 16.3 MP, 4928x3264
 -- AF System: 11 points, 9 cross-type
+-- Coordinates represent the CENTER of the AF point
 
 -- point dimensions
 focusPointDimens = {250, 250}


### PR DESCRIPTION
Awesome! Thanks for the feedback -- you are super fast.

I went ahead and polished up the focus mode selection and added error messages throughout. Now it takes into account every situation that I can think of. This includes unfortunate scenario when you are using face detection but no faces are detected, and the camera does not store any useful focus information.

**About the inactive focus points:**

I uploaded an [album with some sample shots here.](http://imgur.com/a/7HI4c)

The main reason I did that is because Pentax cameras (at least the K-50 and K-1) do not store anything useful in "AFPointSelected" when using the auto-select mode. So basically, you'd just have red dot and nothing else around it. With the inactive points, you get an overview of every point in focus within the entire set of points.

This camera has some pretty poor AF behavior in general. You'll notice from the image that it will indicate that 2 points are in focus when only one is selected, etc. That is a shitty AF system bug that the plugin handles quite correctly, so no biggie. Also, this camera only has 11 points; this might look poor for a camera with many more points. I think your idea about adding a button is good, and should be simple once the interface is little bit more fleshed-out.

Anyway, I think the Pentax stuff works well enough for the K-50 that I can safely add other cameras. I'll start with reddit and see if there are people willing to help out with raw files or by mapping points. Also, let me know if you want me to add some sample images to your other repo.

