### PR TITLE
MOD.156 - Add Metadata filter

### DIFF
--- a/focuspoints.lrdevplugin/ExifUtils.lua
+++ b/focuspoints.lrdevplugin/ExifUtils.lua
@@ -29,11 +29,24 @@ exiftool = LrPathUtils.child(exiftool, "exiftool")
 exiftoolWindows = LrPathUtils.child( _PLUGIN.path, "bin" )
 exiftoolWindows = LrPathUtils.child(exiftoolWindows, "exiftool.exe")
 
+--[[
+-- BEGIN MOD.156 - Add Metadata filter
+-- metaDataFile needs to be a global variable that can be accessed from metaDataDialog
+--]]
+metaDataFile = LrPathUtils.child(LrPathUtils.getStandardFilePath("temp"), LrUUID.generateUUID() .. ".txt")
+
+function ExifUtils.getMetaDataFile()
+  return metaDataFile
+end
+-- END MOD.156 - Add Metadata filter
+
 function ExifUtils.getExifCmd(targetPhoto)
   local path = targetPhoto:getRawMetadata("path")
+  --[[MOD.156 - Add Metadata filter
   local metaDataFile = LrPathUtils.child(LrPathUtils.getStandardFilePath("temp"), LrUUID.generateUUID() .. ".txt")
+  --]]
   local singleQuoteWrap = '\'"\'"\''
-  
+
   local cmd
   if (WIN_ENV) then
     -- windows needs " around the entire command and then " around each path
@@ -53,7 +66,7 @@ function ExifUtils.readMetaData(targetPhoto)
   local cmd, metaDataFile = ExifUtils.getExifCmd(targetPhoto)
   LrTasks.execute(cmd)
   local fileInfo = LrFileUtils.readFile(metaDataFile)
-  LrFileUtils.delete(metaDataFile)
+--LrFileUtils.delete(metaDataFile)
   return fileInfo
 end
 
@@ -89,7 +102,7 @@ end
 function ExifUtils.findFirstMatchingValue(metaDataTable, keys)
   local exifValue = nil
 
-  
+
   for key, value in pairs(keys) do          -- value in the keys table is the current exif keyword to be searched
     exifValue = metaDataTable[value]
 

--- a/focuspoints.lrdevplugin/MetaDataDialog.lua
+++ b/focuspoints.lrdevplugin/MetaDataDialog.lua
@@ -14,7 +14,6 @@
   limitations under the License.
 --]]
 
-
 local LrSystemInfo = import 'LrSystemInfo'
 local LrFunctionContext = import 'LrFunctionContext'
 local LrApplication = import 'LrApplication'
@@ -24,45 +23,143 @@ local LrTasks = import 'LrTasks'
 local LrFileUtils = import 'LrFileUtils'
 local LrPathUtils = import 'LrPathUtils'
 
-MetaDataDialog = {}
+--[[
+-- BEGIN MOD.156 - Add Metadata filter
+-- showMetadataDialog largely rewritten to add entry field w/ observer and "Open as text" button
+--]]
 
-function MetaDataDialog.create(column1, column2, column1Length, column2Length, numLines)
-  local appWidth, appHeight = LrSystemInfo.appWindowSize()
-  local viewFactory = LrView.osFactory()
-  
-  -- these props are needed on windows. on mac, they make the columns a bit larger than needed 
-  if (MAC_ENV) then
-    column1Length = nil
-    column2Length = nil
-  end
-  
-  local myText = viewFactory:static_text {
-    title = column1,
-    selectable = true, 
-    width_in_chars = column1Length,
-    height_in_lines = numLines, 
-    wrap = false,
-  }
-  
-  local myText2 = viewFactory:static_text {
-    title = column2,
-    selectable = true, 
-    width_in_chars = column2Length,
-    height_in_lines = numLines, 
-    wrap = false,
-  }
-  
-  local row = viewFactory:row {
-    myText, myText2, 
-    margin_left = 5, 
-  }
-  
-  local scrollView = viewFactory:scrolled_view {
-    row, 
-    width = appWidth * .7,
-    height = appHeight *.7,
-  }
-  
-  return scrollView
-  
+
+local LrBinding = import 'LrBinding'
+
+require "Utils"
+
+
+function showMetadataDialog(column1, column2, column1Length, column2Length, numLines)
+
+  LrFunctionContext.callWithContext("showMetaDataDialog", function(context)
+
+    local appWidth, appHeight = LrSystemInfo.appWindowSize()
+    local viewFactory = LrView.osFactory()
+    local properties = LrBinding.makePropertyTable( context ) -- make a table
+    local delimiter = "\r"  -- carriage return; used to separate individual entries in column1 and column2 strings
+
+    -- Split column1/column2 strings into arrays of tags/values to ease filtering
+    tagLabels = {};
+    for match in (column1..delimiter):gmatch("(.-)"..delimiter) do
+      table.insert(tagLabels, match);
+    end
+
+    tagValues = {};
+    for match in (column2..delimiter):gmatch("(.-)"..delimiter) do
+      table.insert(tagValues, match);
+    end
+
+    numTags = 0
+    for _ in pairs(tagLabels) do numTags = numTags + 1 end
+
+    -- these props are needed on windows. on mac, they make the columns a bit larger than needed
+    if (MAC_ENV) then
+      column1Length = nil
+      column2Length = nil
+    end
+
+    -- Define the various dialog UI elements
+    local tagFilterLabel = viewFactory:static_text {
+      title = "Show only tags containing:",
+      alignment = 'right',
+    }
+
+  	local tagFilterEntry = viewFactory:edit_field {
+  		immediate = true,
+  	 	value = LrView.bind( 'tagFilter' ),
+      fill_horizonal = 1,
+      width_in_chars = column1Length,
+      immediate = true,
+    }
+
+    local tagFilter = viewFactory:column {
+      tagFilterLabel, tagFilterEntry,
+      margin_left = 5,
+    }
+
+  	-- This function will be called upon user input / whenever "tagFilter" is changed.
+  	local function filterMetadata()
+
+  	  local delimiter = "\r"
+  	  local filteredLabels = ''
+  	  local filteredValues = ''
+  	  local pattern = string.upper(properties.tagFilter)
+
+	    -- Check each individual tag label if it contains tagFilter string
+	    -- if so, keep them along with the respective values
+      for i=1, numTags do
+        if string.find(string.upper(tagLabels[i]), pattern) then
+          filteredLabels = filteredLabels .. tagLabels[i] .. delimiter
+          filteredValues = filteredValues .. tagValues[i] .. delimiter
+        end
+      end
+
+      -- Update view with the filtered entries
+      properties.column1 = filteredLabels
+      properties.column2 = filteredValues
+    end
+
+  	-- Add observer for tagFilter
+	  properties:addObserver( "tagFilter", filterMetadata )
+
+    local myText = viewFactory:static_text {
+      title = LrView.bind "column1",
+      selectable = false,
+      width_in_chars = column1Length,
+      height_in_lines = 1, -- when using numLines as height the window has a lots ob blank space to scroll down (at least on WIN)
+      wrap = false,
+    }
+
+    local myText2 = viewFactory:static_text {
+      title = LrView.bind "column2",
+      selectable = false,
+      width_in_chars = column2Length,
+      height_in_lines = 1, -- same as for myText
+      wrap = false,
+    }
+
+    local row = viewFactory:row {
+      myText, myText2,
+      margin_left = 5,
+    }
+
+    local scrollView = viewFactory:scrolled_view {
+      row,
+      width = appWidth * .4,  -- don't need such wide display, it's scrollable anyway
+      height = appHeight *.7,
+    }
+
+    local contents = viewFactory:column {
+      spacing = viewFactory:label_spacing(),
+      bind_to_object = properties, -- default bound table is the one we made
+      tagFilter,
+      scrollView
+    }
+
+    -- Initialize text for the two columns
+    properties.column1 = column1
+    properties.column2 = column2
+
+    result = LrDialogs.presentModalDialog {
+      title = "Metadata display",
+      resizable = false,  -- resizable dialog makes no sense if scrolled view doesn't resize as well
+      cancelVerb = "< exclude >",
+      actionVerb = "OK",
+      otherVerb = "Open as text",
+      contents = contents
+    }
+
+  end)
+
+  return result
+
 end
+
+--[[
+-- END MOD - Add Metadata filter
+--]]

--- a/focuspoints.lrdevplugin/Utils.lua
+++ b/focuspoints.lrdevplugin/Utils.lua
@@ -26,6 +26,10 @@ local LrPathUtils = import 'LrPathUtils'
 local LrLogger = import 'LrLogger'
 local LrStringUtils = import "LrStringUtils"
 local LrPrefs = import "LrPrefs"
+-- BEGIN MOD - Add Metadata filter
+local LrShell = import "LrShell"
+-- END MOD - Add Metadata filter
+
 
 local prefs = LrPrefs.prefsForPlugin( nil )
 
@@ -87,7 +91,7 @@ function splitTrim(str, delim)
 end
 
 --[[
- Splits a string into 2 parts: key and value. 
+ Splits a string into 2 parts: key and value.
  @str  the string to split
  @delim the character used for splitting the string
 --]]
@@ -106,7 +110,7 @@ end
 --[[
 -- Logging functions. You are provided 5 levels of logging. Wisely choose the level of the message you want to report
 -- to prevent to much messages.
--- Typical use cases: 
+-- Typical use cases:
 --   - logDebug - Informations diagnostically helpful to people (developers, IT, sysadmins, etc.)
 --   - logInfo - Informations generally useful to log (service start/stop, configuration assumptions, etc)
 --   - logWarn - Informations about an unexpected state that won't generate a problem
@@ -224,3 +228,17 @@ function transformCoordinates(x, y, oX, oY, angle, scaleX, scaleY)
 
   return tX, tY
 end
+
+--[[
+-- BEGIN MOD - Add Metadata filter
+-- Open filename in associated application as per file extension
+-- https://community.adobe.com/t5/lightroom-classic/developing-a-publish-plugin-some-api-questions/m-p/11643928#M214559
+--]]
+function openFileInApp(filename)
+  if WIN_ENV then
+    LrShell.openFilesInApp({""}, filename)
+  else
+    LrShell.openFilesInApp({filename}, "open")
+  end
+end
+-- END MOD - Add Metadata filter


### PR DESCRIPTION
Redesign of metadata dialog:
- added entry field to accept string to filter tag names in real time
- added "open as text" button to open the original metadata .txt file in associated application 